### PR TITLE
added README.txt for logi-machine-vision please see pull comments

### DIFF
--- a/logi-machine-vision/README.TXT
+++ b/logi-machine-vision/README.TXT
@@ -1,0 +1,11 @@
+Machine Vision Project *************************************************************************
+* DOCUMENTATION: http://valentfx.com/wiki/index.php?title=LOGI_-_Machine_Vision_-_Project
+* DESCRIPTION  **************
+This proect does not require a camera. It loads an image and processes it
+* INSTRUCTIONS *************
+Generate Programming File using Xilinx ISE open: File | New Project | logi-machine-vision/hw/logipi/ise/logipi_machine_vision.xise
+* TROUBLESHOOTING **********
+Please add HowTo!
+* SUGGESTIONS **************
+Open up the individual project folder to build each project.
+*************************************************************************************


### PR DESCRIPTION
Please move logi-machine-vision to perhaps logi-machine-vision-still or similar.

machine-vision is confusing because: a search for  logi-machine-vision on Google has 4 results, 
this project and 3 others that describe logi-camera-demo.
also pages such as http://valentfx.com/logi-cam/ use machine vision to describe the camera version.

is there a wiki, blog or other description of this project I can link to?

tx