### PR TITLE
add readme and .xise

### DIFF
--- a/logi-camera-demo/README.TXT
+++ b/logi-camera-demo/README.TXT
@@ -1,0 +1,13 @@
+LOGI Image Processing Project *************************************************************************
+* DOCUMENTATION: http://valentfx.com/wiki/index.php?title=LOGI_-_Image_Processing_-_Project
+* DESCRIPTION  **************
+The LOGI image processing demo App is intended to be a plug and play demo of machine vision using the LOGI boarrds.  Machine vision applications are can be very data processing intensive, which makes them a perfect candiate for an FPGA.  The demo capture image data, image processes and streams the data using mpjeg streamer to a networked remote PC.  The user can view the video stream by simply opening a web browser and entering the ip address of the connected bone/pi followed by port :8080.  
+press PB1 (RPi) or use onboard DIP SW (BBB) to toggle through the different image processing modes.  
+* INSTRUCTIONS *************
+Generate Programming File using Xilinx ISE open: File | New Project | logi-edu-demo/hw/logipi/ise/logipi-hw.xise
+* TROUBLESHOOTING **********
+
+* SUGGESTIONS **************
+Open up the individual project folders such as logi-pi-edu-pong to build each project.
+
+*************************************************************************************

--- a/logi-camera-demo/hw/logipi/ise/logipi-hw.xise
+++ b/logi-camera-demo/hw/logipi/ise/logipi-hw.xise
@@ -9,10 +9,10 @@
     <!-- along with the project source files, is sufficient to open and    -->
     <!-- implement in ISE Project Navigator.                               -->
     <!--                                                                   -->
-    <!-- Copyright (c) 1995-2012 Xilinx, Inc.  All rights reserved. -->
+    <!-- Copyright (c) 1995-2013 Xilinx, Inc.  All rights reserved. -->
   </header>
 
-  <version xil_pn:ise_version="14.1" xil_pn:schema_version="2"/>
+  <version xil_pn:ise_version="14.7" xil_pn:schema_version="2"/>
 
   <files>
     <file xil_pn:name="../hdl/logipi_camera.vhd" xil_pn:type="FILE_VHDL">
@@ -147,9 +147,6 @@
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="100"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="34"/>
     </file>
-    <file xil_pn:name="../hdl/logipi_ra3.ucf" xil_pn:type="FILE_UCF">
-      <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
-    </file>
     <file xil_pn:name="../../../../../hard-cv/hw/rtl/image/yuv_to_fifo.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="45"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="36"/>
@@ -194,6 +191,9 @@
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="96"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="32"/>
     </file>
+    <file xil_pn:name="../hdl/logipi_ra3.ucf" xil_pn:type="FILE_UCF">
+      <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
+    </file>
   </files>
 
   <properties>
@@ -221,7 +221,7 @@
     <property xil_pn:name="Change Device Speed To" xil_pn:value="-2" xil_pn:valueState="default"/>
     <property xil_pn:name="Change Device Speed To Post Trace" xil_pn:value="-2" xil_pn:valueState="default"/>
     <property xil_pn:name="Combinatorial Logic Optimization" xil_pn:value="false" xil_pn:valueState="default"/>
-    <property xil_pn:name="Compile EDK Simulation Library" xil_pn:value="true" xil_pn:valueState="default"/>
+    <property xil_pn:name="Compile EDK Simulation Library" xil_pn:value="true" xil_pn:valueState="non-default"/>
     <property xil_pn:name="Compile SIMPRIM (Timing) Simulation Library" xil_pn:value="true" xil_pn:valueState="default"/>
     <property xil_pn:name="Compile UNISIM (Functional) Simulation Library" xil_pn:value="true" xil_pn:valueState="default"/>
     <property xil_pn:name="Compile XilinxCoreLib (CORE Generator) Simulation Library" xil_pn:value="true" xil_pn:valueState="default"/>


### PR DESCRIPTION
apologies if the .xise does not resolve the issue.

the naive visitor should be able to build logi-camera-demo without having to delete and add .ucf file.

I'm just not clear how this might be achieved.